### PR TITLE
support to share imageUrl, imageFile, imageResource; add code example into doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,10 @@ dependencies {
    ...
    compile project(':RCTWeChat')    // Add this line only.
 }
-```
 
 - Add following lines into `MainActivity.java`
 
 ```java
-...
 import com.theweflex.react.WeChatPackage;       // Add this line before public class MainActivity
 
 public class MainActivity extends Activity {
@@ -179,12 +177,91 @@ Share a message to timeline (朋友圈).
 
 - {Object} `data` contain the message to send
     - {String} `thumbImage` Thumb image of the message, which can be a uri or a resource id.
-    - {String} `type` Type of this message. Can be {news|text|image|video|audio|file}
+    - {String} `type` Type of this message. Can be {news|text|imageUrl|imageFile|imageResource|video|audio|file}
     - {String} `webpageUrl` Required if type equals `news`. The webpage link to share.
     - {String} `imageUrl` Provide a remote image if type equals `image`.
     - {String} `videoUrl` Provide a remote video if type equals `video`.
     - {String} `musicUrl` Provide a remote music if type equals `audio`.
     - {String} `filePath` Provide a local file if type equals `file`.
+
+these example need 'react-native-chat' and 'react-native-fs' plugin.
+```javascript
+import * as WeChat from 'react-native-wechat';
+import fs from 'react-native-fs';
+var resolveAssetSource = require('resolveAssetSource'); // along with Image component
+```
+
+1, code example to share text message:
+```javascript
+try {
+    var result = await  WeChat.shareToTimeline({type: 'text', description: 'I\'m Wechat, :)'});
+    console.log('share text message to time line successful', result);
+}
+catch (e) {
+    console.log('share text message to time line failed', e);
+}
+```
+2, code example to share image url:
+```javascript
+try {
+    var result = await WeChat.shareToTimeline({
+        type: 'imageUrl',
+        title: 'web image',
+        description: 'share web image to time line',
+        mediaTagName: 'email signature',
+        messageAction: undefined,
+        messageExt: undefined,
+        imageUrl: 'http://www.ncloud.hk/email-signature-262x100.png'
+    });
+    console.log('share image url to time line successful', result);
+}
+catch (e) {
+    console.log('share image url to time line failed', e);
+}
+```
+3, code example to share image file:
+```javascript
+try {
+    var rootPath = fs.DocumentDirectoryPath;
+    var savePath = rootPath + '/email-signature-262x100.png'; // like /var/mobile/Containers/Data/Application/B1308E13-35F1-41AB-A20D-3117BE8EE8FE/Documents/email-signature-262x100.png
+
+    await fs.downloadFile('http://www.ncloud.hk/email-signature-262x100.png', savePath);
+
+    var result = await WeChat.shareToTimeline({
+        type: 'imageFile',
+        title: 'image file download from network',
+        description: 'share image file to time line',
+        mediaTagName: 'email signature',
+        messageAction: undefined,
+        messageExt: undefined,
+        imageUrl: savePath
+    });
+
+    console.log('share image file to time line successful', result);
+}
+catch (e) {
+    console.log('share image file to time line failed', e);
+}
+```
+4, code example to share image resource:
+```javascript
+try {
+    var imageResource = require('./email-signature-262x100.png');
+    var result = await WeChat.shareToTimeline({
+        type: 'imageResource',
+        title: 'resource image',
+        description: 'share resource image to time line',
+        mediaTagName: 'email signature',
+        messageAction: undefined,
+        messageExt: undefined,
+        imageUrl: resolveAssetSource(imageResource).uri
+    });
+    console.log('share resource image to time line successful', result);
+}
+catch (e) {
+    console.log('share resource image to time line failed', e);
+}
+```
 
 #### shareToSession(data)
 

--- a/ios/RCTWeChat.h
+++ b/ios/RCTWeChat.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "RCTBridgeModule.h"
+#import "WXApi.h"
 
 // define share type constants
 #define RCTWXShareTypeNews @"news"
@@ -22,7 +23,7 @@
 #define RCTWXShareWebpageUrl @"webpageUrl"
 #define RCTWXShareImageUrl @"imageUrl"
 
-@interface RCTWeChat : NSObject <RCTBridgeModule>
+@interface RCTWeChat : NSObject <RCTBridgeModule, WXApiDelegate>
 
 @property NSString* appId;
 

--- a/ios/RCTWeChat.h
+++ b/ios/RCTWeChat.h
@@ -12,7 +12,9 @@
 
 // define share type constants
 #define RCTWXShareTypeNews @"news"
-#define RCTWXShareTypeImage @"image"
+#define RCTWXShareTypeImageUrl @"imageUrl"
+#define RCTWXShareTypeImageFile @"imageFile"
+#define RCTWXShareTypeImageResource @"imageResource"
 #define RCTWXShareTypeText @"text"
 #define RCTWXShareTypeVideo @"video"
 #define RCTWXShareTypeAudio @"audio"

--- a/ios/RCTWeChat.m
+++ b/ios/RCTWeChat.m
@@ -37,13 +37,17 @@ RCT_EXPORT_MODULE()
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (BOOL)handleOpenUrl:(NSURL *)aUrl
+- (BOOL)handleOpenURL:(NSNotification *)aNotification
 {
-    if ([WXApi handleOpenURL:aUrl delegate:self])
+    NSString * aURLString =  [aNotification userInfo][@"url"];
+    NSURL * aURL = [NSURL URLWithString:aURLString];
+
+    if ([WXApi handleOpenURL:aURL delegate:self])
     {
         return YES;
+    } else {
+        return NO;
     }
-    return NO;
 }
 
 - (dispatch_queue_t)methodQueue

--- a/ios/RCTWeChat.m
+++ b/ios/RCTWeChat.m
@@ -155,63 +155,117 @@ RCT_EXPORT_METHOD(shareToSession:(NSDictionary *)data
                         scene:(int)aScene
                      callBack:(RCTResponseSenderBlock)callback
 {
-    SendMessageToWXReq* req = [SendMessageToWXReq new];
-    req.scene = aScene;
-    
     NSString *type = aData[RCTWXShareType];
-    
+
     if ([type isEqualToString:RCTWXShareTypeText]) {
-        req.bText = YES;
-        
         NSString *text = aData[RCTWXShareDescription];
-        if (text && [text isKindOfClass:[NSString class]]) {
-            req.text = text;
-        }
+        [self shareToWeixinWithTextMessage:aScene Text:text callBack:callback];
     } else {
-        req.bText = NO;
-        
-        WXMediaMessage* mediaMessage = [WXMediaMessage new];
-        
-        mediaMessage.title = aData[RCTWXShareTitle];
-        mediaMessage.description = aData[RCTWXShareDescription];
-        mediaMessage.mediaTagName = aData[@"mediaTagName"];
-        mediaMessage.messageAction = aData[@"messageAction"];
-        mediaMessage.messageExt = aData[@"messageExt"];
-        
-        [mediaMessage setThumbImage:aThumbImage];
-        
+        NSString * title = aData[RCTWXShareTitle];
+        NSString * description = aData[RCTWXShareDescription];
+        NSString * mediaTagName = aData[@"mediaTagName"];
+        NSString * messageAction = aData[@"messageAction"];
+        NSString * messageExt = aData[@"messageExt"];
+
         if (type.length <= 0 || [type isEqualToString:RCTWXShareTypeNews]) {
-            WXWebpageObject* webpageObject = [WXWebpageObject new];
-            webpageObject.webpageUrl = aData[RCTWXShareWebpageUrl];
-            mediaMessage.mediaObject = webpageObject;
-            
-            if (webpageObject.webpageUrl.length<=0) {
+            NSString * webpageUrl = aData[RCTWXShareWebpageUrl];
+            if (webpageUrl.length <= 0) {
                 callback(@[@"webpageUrl required"]);
                 return;
             }
+
+            WXWebpageObject* webpageObject = [WXWebpageObject object];
+            webpageObject.webpageUrl = aData[RCTWXShareWebpageUrl];
+
+            [self shareToWeixinWithMediaMessage:aScene
+                                          Title:title
+                                    Description:description
+                                         Object:webpageObject
+                                     MessageExt:messageExt
+                                  MessageAction:messageAction
+                                     ThumbImage:aThumbImage
+                                       MediaTag:mediaTagName
+                                       callBack:callback];
+
         } else if ([type isEqualToString:RCTWXShareTypeAudio]) {
             WXMusicObject *musicObject = [WXMusicObject new];
             musicObject.musicUrl = aData[@"musicUrl"];
             musicObject.musicLowBandUrl = aData[@"musicLowBandUrl"];
             musicObject.musicDataUrl = aData[@"musicDataUrl"];
             musicObject.musicLowBandDataUrl = aData[@"musicLowBandDataUrl"];
-            mediaMessage.mediaObject = musicObject;
+
+            [self shareToWeixinWithMediaMessage:aScene
+                                          Title:title
+                                    Description:description
+                                         Object:musicObject
+                                     MessageExt:messageExt
+                                  MessageAction:messageAction
+                                     ThumbImage:aThumbImage
+                                       MediaTag:mediaTagName
+                                       callBack:callback];
+
         } else if ([type isEqualToString:RCTWXShareTypeVideo]) {
             WXVideoObject *videoObject = [WXVideoObject new];
             videoObject.videoUrl = aData[@"videoUrl"];
             videoObject.videoLowBandUrl = aData[@"videoLowBandUrl"];
-            mediaMessage.mediaObject = videoObject;
-        } else if ([type isEqualToString:RCTWXShareTypeImage]) {
-            WXImageObject *imageObject = [WXImageObject new];
-            imageObject.imageUrl = aData[RCTWXShareImageUrl];
-            mediaMessage.mediaObject = imageObject;
+
+            [self shareToWeixinWithMediaMessage:aScene
+                                          Title:title
+                                    Description:description
+                                         Object:videoObject
+                                     MessageExt:messageExt
+                                  MessageAction:messageAction
+                                     ThumbImage:aThumbImage
+                                       MediaTag:mediaTagName
+                                       callBack:callback];
+
+        } else if ([type isEqualToString:@"imageURL"]) {
+            NSString * imageURL = aData[RCTWXShareImageUrl];
+
+            WXImageObject *imageObject = [WXImageObject object];
+            imageObject.imageUrl = imageURL;
+
+            [self shareToWeixinWithMediaMessage:aScene
+                                          Title:title
+                                    Description:description
+                                         Object:imageObject
+                                     MessageExt:messageExt
+                                  MessageAction:messageAction
+                                     ThumbImage:aThumbImage
+                                       MediaTag:mediaTagName
+                                       callBack:callback];
+
+        } else if ([type isEqualToString:@"imageFile"]) {
+            callback(@[@"not implement yet"]);
+        } else if ([type isEqualToString:@"imageResource"]) {
+            NSString * imageURL = aData[RCTWXShareImageUrl];
+
+            if (self.bridge.imageLoader == nil){
+                callback(@[@"fail to load image resource"]);
+            }
+
+            [self.bridge.imageLoader loadImageWithTag:imageURL callback:^(NSError *error, UIImage *image) {
+                if (image == nil){
+                    callback(@[@"fail to load image resource"]);
+                } else {
+                    WXImageObject *imageObject = [WXImageObject object];
+                    imageObject.imageData = UIImagePNGRepresentation(image);
+
+                    [self shareToWeixinWithMediaMessage:aScene
+                                                  Title:title
+                                            Description:description
+                                                 Object:imageObject
+                                             MessageExt:messageExt
+                                          MessageAction:messageAction
+                                             ThumbImage:aThumbImage
+                                               MediaTag:mediaTagName
+                                               callBack:callback];
+
+                }
+            }];
+        } else {
+            callback(@[@"message type unsupported"]);
         }
-        req.message = mediaMessage;
-    }
-    
-    BOOL success = [WXApi sendReq:req];
-    if (success == NO) {
-        callback(@[INVOKE_FAILED]);
     }
 }
 
@@ -220,13 +274,56 @@ RCT_EXPORT_METHOD(shareToSession:(NSDictionary *)data
 {
     NSString *imageUrl = aData[@"thumbImage"];
     if (imageUrl.length && _bridge.imageLoader) {
-        [_bridge.imageLoader loadImageWithTag:imageUrl size:CGSizeMake(100, 100) scale:1 resizeMode:UIViewContentModeScaleToFill progressBlock:nil completionBlock:^(NSError *error, UIImage *image) {
-            [self shareToWeixinWithData:aData thumbImage:image scene:aScene callBack:aCallBack];
-        }];
+        [_bridge.imageLoader loadImageWithTag:imageUrl size:CGSizeMake(100, 100) scale:1 resizeMode:RCTResizeModeStretch progressBlock:nil completionBlock:
+            ^(NSError *error, UIImage *image) {
+                [self shareToWeixinWithData:aData thumbImage:image scene:aScene callBack:aCallBack];
+            }
+         ];
     } else {
         [self shareToWeixinWithData:aData thumbImage:nil scene:aScene callBack:aCallBack];
     }
-    
+
+}
+
+- (void)shareToWeixinWithTextMessage:(int)aScene
+                                Text:(NSString *)text
+                                callBack:(RCTResponseSenderBlock)callback
+{
+    SendMessageToWXReq* req = [SendMessageToWXReq new];
+    req.bText = YES;
+    req.scene = aScene;
+    req.text = text;
+
+    BOOL success = [WXApi sendReq:req];
+    callback(@[success ? [NSNull null] : INVOKE_FAILED]);
+}
+
+- (void)shareToWeixinWithMediaMessage:(int)aScene
+                                Title:(NSString *)title
+                          Description:(NSString *)description
+                               Object:(id)mediaObject
+                           MessageExt:(NSString *)messageExt
+                        MessageAction:(NSString *)action
+                           ThumbImage:(UIImage *)thumbImage
+                             MediaTag:(NSString *)tagName
+                             callBack:(RCTResponseSenderBlock)callback
+{
+    WXMediaMessage *message = [WXMediaMessage message];
+    message.title = title;
+    message.description = description;
+    message.mediaObject = mediaObject;
+    message.messageExt = messageExt;
+    message.messageAction = action;
+    message.mediaTagName = tagName;
+    [message setThumbImage:thumbImage];
+
+    SendMessageToWXReq* req = [SendMessageToWXReq new];
+    req.bText = NO;
+    req.scene = aScene;
+    req.message = message;
+
+    BOOL success = [WXApi sendReq:req];
+    callback(@[success ? [NSNull null] : INVOKE_FAILED]);
 }
 
 #pragma mark - wx callback

--- a/ios/RCTWeChat.m
+++ b/ios/RCTWeChat.m
@@ -12,6 +12,7 @@
 #import "Base/RCTBridge.h"
 #import "Base/RCTLog.h"
 #import "RCTImageLoader.h"
+#import "RCTImageUtils.h"
 
 // Define error messages
 #define NOT_REGISTERED (@"registerApp required.")
@@ -220,7 +221,7 @@ RCT_EXPORT_METHOD(shareToSession:(NSDictionary *)data
                                        callBack:callback];
 
         } else if ([type isEqualToString:@"imageURL"]) {
-            NSString * imageURL = aData[RCTWXShareImageUrl];
+            NSString * imageURL = aData[@"imageURL"];
 
             WXImageObject *imageObject = [WXImageObject object];
             imageObject.imageUrl = imageURL;
@@ -235,21 +236,15 @@ RCT_EXPORT_METHOD(shareToSession:(NSDictionary *)data
                                        MediaTag:mediaTagName
                                        callBack:callback];
 
-        } else if ([type isEqualToString:@"imageFile"]) {
-            callback(@[@"not implement yet"]);
-        } else if ([type isEqualToString:@"imageResource"]) {
-            NSString * imageURL = aData[RCTWXShareImageUrl];
-
-            if (self.bridge.imageLoader == nil){
-                callback(@[@"fail to load image resource"]);
-            }
-
+        } else if ([type isEqualToString:@"imageFile"] || [type isEqualToString:@"imageResource"]) {
+            NSString * imageURL = aData[@"imageURL"];
+            
             [self.bridge.imageLoader loadImageWithTag:imageURL callback:^(NSError *error, UIImage *image) {
                 if (image == nil){
                     callback(@[@"fail to load image resource"]);
                 } else {
                     WXImageObject *imageObject = [WXImageObject object];
-                    imageObject.imageData = UIImagePNGRepresentation(image);
+                    imageObject.imageData = RCTGetImageData([image CGImage], 1.0F);
 
                     [self shareToWeixinWithMediaMessage:aScene
                                                   Title:title

--- a/ios/RCTWeChat.m
+++ b/ios/RCTWeChat.m
@@ -7,7 +7,6 @@
 //
 
 #import "RCTWeChat.h"
-#import "WXApi.h"
 #import "WXApiObject.h"
 #import "Base/RCTEventDispatcher.h"
 #import "Base/RCTBridge.h"

--- a/ios/RCTWeChat.m
+++ b/ios/RCTWeChat.m
@@ -220,8 +220,8 @@ RCT_EXPORT_METHOD(shareToSession:(NSDictionary *)data
                                        MediaTag:mediaTagName
                                        callBack:callback];
 
-        } else if ([type isEqualToString:@"imageURL"]) {
-            NSString * imageURL = aData[@"imageURL"];
+        } else if ([type isEqualToString:RCTWXShareTypeImageUrl]) {
+            NSString * imageURL = aData[RCTWXShareImageUrl];
 
             WXImageObject *imageObject = [WXImageObject object];
             imageObject.imageUrl = imageURL;
@@ -236,8 +236,8 @@ RCT_EXPORT_METHOD(shareToSession:(NSDictionary *)data
                                        MediaTag:mediaTagName
                                        callBack:callback];
 
-        } else if ([type isEqualToString:@"imageFile"] || [type isEqualToString:@"imageResource"]) {
-            NSString * imageURL = aData[@"imageURL"];
+        } else if ([type isEqualToString:RCTWXShareTypeImageFile] || [type isEqualToString:RCTWXShareTypeImageResource]) {
+            NSString * imageURL = aData[RCTWXShareImageUrl];
             
             [self.bridge.imageLoader loadImageWithTag:imageURL callback:^(NSError *error, UIImage *image) {
                 if (image == nil){

--- a/ios/RCTWeChat.xcodeproj/project.pbxproj
+++ b/ios/RCTWeChat.xcodeproj/project.pbxproj
@@ -219,9 +219,8 @@
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SRCROOT)/../node_modules/react-native/React/**",
-					"$(SRCROOT)/../Example/node_modules/react-native/React/**",
-					"$(SRCROOT)/../Example/node_modules/react-native/Libraries/**",
+					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../react-native/Libraries/Image/**",
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -238,9 +237,8 @@
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SRCROOT)/../node_modules/react-native/React/**",
-					"$(SRCROOT)/../Example/node_modules/react-native/React/**",
-					"$(SRCROOT)/../Example/node_modules/react-native/Libraries/**",
+					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../react-native/Libraries/Image/**",
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
- RCTWeChat should adopt the WXApiDelegate protocol
- fix Header Search Path issue of the project
- fix handleOpenURL issue, typo in method name and the first argument should be (NSNotification *)aNotification but (NSURL *)aUrl; please refer Apple document: https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSNotificationCenter_Class/
- support to share imageUrl, imageFile, imageResource
- add code example into doc