### PR TITLE
Update peerDependency for react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "events": "1.0.2"
   },
   "peerDependencies": {
-    "react-native": ">=0.17"
+    "react-native": ">=0.20"
   },
   "author": "Yorkie Liu <yorkiefixer@gmail.com>",
   "contributors": [


### PR DESCRIPTION
I found that the RCTResizeMode.h file had been introduced into react-native Image library on 21 Jan 2016( facebook/react-native@21fcbbc), and the earliest release version that contain this file is 0.20.0 witch was released on 16 Feb 2016 (facebook/react-native@6496feb).

So, I think we should update the dependency react-native version to 0.20.0.