### PR TITLE
fix(index.js:sendAuthRequest):get auth response data

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,22 +76,19 @@ const nativeShareToSession = wrapApi(WeChat.shareToSession);
 const nativeSendAuthRequest = wrapApi(WeChat.sendAuthRequest);
 
 export function sendAuthRequest(scopes, state) {
-  // Generate a random, unique state if not provided.
-  return new Promise(resolve, reject=> {
-   
-    WeChat.sendAuthRequest(_scopes, _state,()=> {});
-
-    emitter.on("SendAuth.Resp", (resp) => {
+  return new Promise((resolve, reject)=> {
+    WeChat.sendAuthRequest(scopes, state,()=> {});
+    emitter.on('SendAuth.Resp', (resp) => {
       const result = resp.errCode;
-      if(result == 0){
+      if(result === 0){
         const code = resp.code;
-        resolve(code)
+        resolve(code);
       }else{
         const errorCode = result;
-        reject(errorCode)
+        reject(errorCode);
       }
     });
-  })
+  });
 }
 
 export function shareToTimeline(data) {

--- a/index.js
+++ b/index.js
@@ -77,12 +77,30 @@ const nativeSendAuthRequest = wrapApi(WeChat.sendAuthRequest);
 
 export function sendAuthRequest(scopes, state) {
   // Generate a random, unique state if not provided.
-  let _scopes = scopes || 'snsapi_userinfo';
-  if (Array.isArray(_scopes)) {
-    _scopes = _scopes.join(',');
-  }
-  const _state = state || Math.random().toString(16).substr(2) + '_' + new Date().getTime();
-  return nativeSendAuthRequest(_scopes, _state).then(v => v[0]);
+  return new Promise((resolve, reject)=> {
+    let _scopes = scopes || 'snsapi_userinfo';
+    if (Array.isArray(_scopes)) {
+      _scopes = _scopes.join(',');
+    }
+    const _state = state || Math.random().toString(16).substr(2) + '_' + new Date().getTime();
+
+    WeChat.sendAuthRequest(_scopes, _state,()=> {});
+
+    emitter.on("SendAuth.Resp", (resp) => {
+      const result = resp.errCode;
+      if(result == 0){
+        const message = "登陆成功";
+        const code = resp.code;
+        const eo_data = {result,message,code}
+        resolve(eo_data)
+      }else{
+        const errorCode = result;
+        const message = "用户取消登陆"
+        const eo_data = {errorCode,message}
+        reject(eo_data)
+      }
+    });
+  })
 }
 
 export function shareToTimeline(data) {

--- a/index.js
+++ b/index.js
@@ -80,12 +80,10 @@ export function sendAuthRequest(scopes, state) {
     WeChat.sendAuthRequest(scopes, state,() => {});
     emitter.on('SendAuth.Resp', (resp) => {
       const result = resp.errCode;
-      if(result === 0){
-        const code = resp.code;
-        resolve(code);
-      }else{
-        const errorCode = result;
-        reject(errorCode);
+      if (result === 0) {
+        resolve(resp.code);
+      } else {
+        reject(result);
       }
     });
   });

--- a/index.js
+++ b/index.js
@@ -76,8 +76,8 @@ const nativeShareToSession = wrapApi(WeChat.shareToSession);
 const nativeSendAuthRequest = wrapApi(WeChat.sendAuthRequest);
 
 export function sendAuthRequest(scopes, state) {
-  return new Promise((resolve, reject)=> {
-    WeChat.sendAuthRequest(scopes, state,()=> {});
+  return new Promise((resolve, reject) => {
+    WeChat.sendAuthRequest(scopes, state,() => {});
     emitter.on('SendAuth.Resp', (resp) => {
       const result = resp.errCode;
       if(result === 0){

--- a/index.js
+++ b/index.js
@@ -77,27 +77,18 @@ const nativeSendAuthRequest = wrapApi(WeChat.sendAuthRequest);
 
 export function sendAuthRequest(scopes, state) {
   // Generate a random, unique state if not provided.
-  return new Promise((resolve, reject)=> {
-    let _scopes = scopes || 'snsapi_userinfo';
-    if (Array.isArray(_scopes)) {
-      _scopes = _scopes.join(',');
-    }
-    const _state = state || Math.random().toString(16).substr(2) + '_' + new Date().getTime();
-
+  return new Promise(resolve, reject=> {
+   
     WeChat.sendAuthRequest(_scopes, _state,()=> {});
 
     emitter.on("SendAuth.Resp", (resp) => {
       const result = resp.errCode;
       if(result == 0){
-        const message = "登陆成功";
         const code = resp.code;
-        const eo_data = {result,message,code}
-        resolve(eo_data)
+        resolve(code)
       }else{
         const errorCode = result;
-        const message = "用户取消登陆"
-        const eo_data = {errorCode,message}
-        reject(eo_data)
+        reject(errorCode)
       }
     });
   })


### PR DESCRIPTION
## return promise after SendAuth.Resp event emitted

## Usage
# es7:
```
async handleWechatLogin(event){
    try {
     const result = await WeChat.sendAuthRequest(scope, state)
     console.log(result);
   } catch (e) {
     console.error(e);
   }
}
```
# es6: 
```
 handleWechatLogin(event){
     WeChat.sendAuthRequest(scope, state)
      .then((result)=>{
        console.log(result)
      })
      .catch((e)=>{
        console.error(e);
      })
}
```