### PR TITLE
ios: fix header path for installed mode under node_modules

### DIFF
--- a/ios/RCTWeChat.xcodeproj/project.pbxproj
+++ b/ios/RCTWeChat.xcodeproj/project.pbxproj
@@ -221,6 +221,8 @@
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native/Libraries/Image/**",
+					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../react-native/Libraries/**",
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -239,6 +241,8 @@
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native/Libraries/Image/**",
+					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../react-native/Libraries/**",
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
Fixes: https://github.com/weflex/react-native-wechat/issues/89

R= @xing-zheng 
/cc @Richard-Cao