### PR TITLE
更正APP从服务端获取支付参数后提交订单时提取参数错误

### DIFF
--- a/ios/RCTWeChat.m
+++ b/ios/RCTWeChat.m
@@ -155,10 +155,10 @@ RCT_EXPORT_METHOD(pay:(NSDictionary *)data
                   :(RCTResponseSenderBlock)callback)
 {
     PayReq* req             = [PayReq new];
-    req.partnerId           = data[@"partnerId"];
-    req.prepayId            = data[@"prepayId"];
-    req.nonceStr            = data[@"nonceStr"];
-    req.timeStamp           = [data[@"timeStamp"] unsignedIntValue];
+    req.partnerId           = data[@"partnerid"];
+    req.prepayId            = data[@"prepayid"];
+    req.nonceStr            = data[@"noncestr"];
+    req.timeStamp           = [data[@"timestamp"] unsignedIntValue];
     req.package             = data[@"package"];
     req.sign                = data[@"sign"];
     BOOL success = [WXApi sendReq:req];


### PR DESCRIPTION
微信支付服务端SDK响应客户端支付请求，客户端从返回支付参数Object中取值时，键名应全部小写，而非驼峰。

> 官方SDK示例：

``` javascript
PayReq* req             = [[[PayReq alloc] init]autorelease];
req.partnerId           = [dict objectForKey:@"partnerid"];
req.prepayId            = [dict objectForKey:@"prepayid"];
req.nonceStr            = [dict objectForKey:@"noncestr"];
req.timeStamp           = stamp.intValue;
req.package             = [dict objectForKey:@"package"];
req.sign                = [dict objectForKey:@"sign"];
[WXApi sendReq:req];
```
