### PR TITLE
Fix native module WeChatModule tried to override WeChatModule

### DIFF
--- a/android/src/main/java/com/theweflex/react/WeChatModule.java
+++ b/android/src/main/java/com/theweflex/react/WeChatModule.java
@@ -68,6 +68,15 @@ public class WeChatModule extends ReactContextBaseJavaModule implements IWXAPIEv
         return "RCTWeChat";
     }
 
+    /**
+     * fix Native module WeChatModule tried to override WeChatModule for module name RCTWeChat.
+     * If this was your intention, return true from WeChatModule#canOverrideExistingModule() bug
+     * @return
+     */
+    public boolean canOverrideExistingModule(){
+        return true;
+    }
+
     private static ArrayList<WeChatModule> modules = new ArrayList<>();
 
     @Override


### PR DESCRIPTION
Fix native module WeChatModule tried to override WeChatModule for module name RCTWeChat.If this was your intention, return true from WeChatModule#canOverrideExistingModule() bug