### PR TITLE
React Native <0.40> IOS import syntax change for referencing native libraries

### DIFF
--- a/ios/RCTWeChat.h
+++ b/ios/RCTWeChat.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 #import "WXApi.h"
 
 // define share type constants

--- a/ios/RCTWeChat.h
+++ b/ios/RCTWeChat.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#import <React/RCTBridgeModule.h>
+#import <React/RCTBridge.h>
 #import "WXApi.h"
 
 // define share type constants

--- a/ios/RCTWeChat.m
+++ b/ios/RCTWeChat.m
@@ -8,11 +8,11 @@
 
 #import "RCTWeChat.h"
 #import "WXApiObject.h"
-#import "RCTEventDispatcher.h"
-#import "RCTBridge.h"
-#import "RCTLog.h"
-#import "RCTImageLoader.h"
-#import "RCTImageUtils.h"
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTBridge.h>
+#import <React/RCTLog.h>
+#import <React/RCTImageLoader.h>
+#import <React/RCTImageUtils.h>
 
 // Define error messages
 #define NOT_REGISTERED (@"registerApp required.")


### PR DESCRIPTION
#import "RCTUtils.h" -> #import <React/RCTUtils.h>
See reference docs here:
https://github.com/facebook/react-native/releases/tag/v0.40.0