### PR TITLE
js: dont throw Promise error anymore if registered app

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ function wrapRegisterApp(nativeFunc) {
   }
   return (...args) => {
     if (isAppRegistered) {
-      return Promise.reject(new Error('App is already registered.'));
+      // FIXME(Yorkie): we ignore this error if AppRegistered is true.
+      return Promise.resolve(true);
     }
     isAppRegistered = true;
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
Inspired by #167, most of cases in userland doesn't know how to handle this "app registered" error, so I think remove this error and just let user call this function is enough.

This still might be an minor change, because someone may handle this error still.